### PR TITLE
Fix GitHub API auth, improve error handling, and add file locking

### DIFF
--- a/repository_search/GitHubSearch.py
+++ b/repository_search/GitHubSearch.py
@@ -30,7 +30,7 @@ class GitHubSearch:
         commits_url = f"https://api.github.com/repos/{full_name}/commits"
         headers = {}
         if self.github_token:
-            headers['Authorization'] = f'token {self.github_token}'
+            headers['Authorization'] = f'Bearer {self.github_token}'
         params = {"per_page": 1}
         response = requests.get(commits_url, headers=headers, params=params)
         if response.status_code == 200:
@@ -202,6 +202,10 @@ class GitHubSearch:
             if page > 1:
                 response = self._github_search_request(headers, {**params, "page": page})
                 if response is None:
+                    print(
+                        f"Warning: GitHub API returned no response at page {page} of size range "
+                        f"[{size_start}, {size_end}). Successfully retrieved {page - 1} page(s) before failure."
+                    )
                     break
                 data = response.json()
 
@@ -213,6 +217,7 @@ class GitHubSearch:
                 full_name = repo.get("full_name")
                 if full_name in processed_repos:
                     continue
+                processed_repos.add(full_name)
                 print(f"Processing repository: {full_name}")
                 success = self.process_repository_with_timeout(full_name)
                 if not success:
@@ -221,7 +226,6 @@ class GitHubSearch:
                 latest_commit = self.get_latest_commit(full_name)
                 with self.processed_file.open("a", encoding="utf-8") as f:
                     f.write(f"{full_name}|{latest_commit}\n")
-                processed_repos.add(full_name)
 
                 self.run_pytest_check(full_name)
 
@@ -253,7 +257,7 @@ class GitHubSearch:
 
         headers = {}
         if self.github_token:
-            headers['Authorization'] = f'token {self.github_token}'
+            headers['Authorization'] = f'Bearer {self.github_token}'
 
         license_filters = [
             f"license:mit language:python stars:>={stars}",
@@ -289,7 +293,10 @@ class GitHubSearch:
         if p.is_alive():
             print(f"Timeout while processing {full_name}. Killing process.")
             p.terminate()
-            p.join()
+            p.join(timeout=30)
+            if p.is_alive():
+                p.kill()
+                p.join()
             timed_out = True
 
         duration = time.time() - start
@@ -326,10 +333,17 @@ def run_processor_in_venv(full_name, repository_path, out_path, venv_path):
 
     subprocess.run([python_bin, "-m", "pip", "install", "pytest", "coverage"], timeout=600, check=False)
 
-    subprocess.check_call([
-        python_bin, "-u", str(miner),
-        full_name, repository_path, out_path
-    ], timeout=PROCESS_TIMEOUT + 60, env=env)
+    try:
+        subprocess.check_call([
+            python_bin, "-u", str(miner),
+            full_name, repository_path, out_path
+        ], timeout=PROCESS_TIMEOUT + 60, env=env)
+    except subprocess.TimeoutExpired:
+        print(f"Subprocess timed out while processing {full_name}.")
+        raise
+    except subprocess.CalledProcessError as e:
+        print(f"Subprocess failed for {full_name} with exit code {e.returncode}.")
+        raise
 
 
 if __name__ == "__main__":

--- a/repository_search/main_repository_miner.py
+++ b/repository_search/main_repository_miner.py
@@ -1,4 +1,5 @@
 import csv
+import fcntl
 import os
 import shutil
 import stat
@@ -49,13 +50,17 @@ class Main:
 
     def save_case(self, repository_name, annotated_code, relative_path, broken_hash, repaired_hash, log):
         output_file = Path(self.out_path) / "annotated_cases.csv"
-        file_exists = output_file.exists()
 
         with output_file.open("a", newline='', encoding="utf-8") as csvfile:
-            writer = csv.writer(csvfile, delimiter='|')
-            if not file_exists:
-                writer.writerow(["repository_name", "annotated_code", "relative_path", "broken_hash", "repaired_hash", "outdated_test_log"])
-            writer.writerow([repository_name, annotated_code, relative_path, broken_hash, repaired_hash, log])
+            fcntl.flock(csvfile, fcntl.LOCK_EX)
+            try:
+                write_header = output_file.stat().st_size == 0
+                writer = csv.writer(csvfile, delimiter='|', quoting=csv.QUOTE_ALL)
+                if write_header:
+                    writer.writerow(["repository_name", "annotated_code", "relative_path", "broken_hash", "repaired_hash", "outdated_test_log"])
+                writer.writerow([repository_name, annotated_code, relative_path, broken_hash, repaired_hash, log])
+            finally:
+                fcntl.flock(csvfile, fcntl.LOCK_UN)
 
         print(f"Saved annotated case for repository '{repository_name}' to {output_file}")
         

--- a/repository_search/repository_actions.py
+++ b/repository_search/repository_actions.py
@@ -49,7 +49,10 @@ class RepositoryActions:
 
         print(f"Cloning repository from {repo_url} to {dest_dir}...")
         cmd = ["git", "clone", repo_url, dest_dir]
-        subprocess.run(cmd, capture_output=True, text=True, env=os.environ)
+        clone_result = subprocess.run(cmd, capture_output=True, text=True, env=os.environ)
+        if clone_result.returncode != 0:
+            print(f"Failed to clone {repo_url}: {clone_result.stderr}")
+            raise Exception(f"git clone failed for {self.repository_name}")
 
         cmd = [sys.executable, "-m", "pip", "install", "."]
         result = subprocess.run(cmd, capture_output=True, text=True, env=os.environ, cwd=dest_dir)
@@ -207,7 +210,7 @@ class RepositoryActions:
 
                 # ---------- child must PASS ----------
                 if self.move_to_later_commit() == "Error":
-                    continue
+                    break
                 child = compile_and_run_test_python(self.repo_dir, rel_path, test_method, self.repo_dir.parent)
 
                 if child.status != TestVerdict.SUCCESS:
@@ -684,6 +687,13 @@ class RepositoryActions:
         test_file_path = self.repo_dir / rel_path
         nodeid = f"{test_file_path.as_posix()}::{test_method}"
 
+        # Remove stale coverage files from previous runs before starting.
+        for stale in self.repo_dir.glob(".coverage*"):
+            try:
+                stale.unlink()
+            except Exception:
+                pass
+
         # Run the test via coverage in parallel mode.
         cmd = [
             sys.executable, "-m", "coverage", "run", "--parallel-mode", "-m", "pytest",
@@ -698,6 +708,10 @@ class RepositoryActions:
         combine_return, combine_log = run_cmd(combine_cmd, timeout=15 * 60, cwd=str(self.repo_dir), env=env)
         print("Coverage combine returned:", combine_return)
         print("Coverage combine log:", combine_log)
+
+        if combine_return != 0:
+            print(f"Coverage combine failed (return code {combine_return}). Skipping coverage load.")
+            return None
 
         # Load the combined coverage data.
         cov_data_file = self.repo_dir / ".coverage"


### PR DESCRIPTION
## Summary
This PR addresses several reliability and correctness issues in the repository mining pipeline, including GitHub API authentication updates, improved error handling for subprocess operations, and thread-safe file writing.

## Key Changes

### GitHub API Authentication
- Updated GitHub API authorization header from `token` to `Bearer` format in two locations (`get_latest_commit` and `find_and_process_repositories`)

### Error Handling & Robustness
- Added warning message when GitHub API returns no response during pagination, reporting the page number and successful pages retrieved
- Enhanced subprocess timeout handling in `process_repository_with_timeout` to forcefully kill processes that don't terminate gracefully (added `p.kill()` after `p.terminate()`)
- Added try-catch blocks around subprocess calls in `run_processor_in_venv` to catch and report `TimeoutExpired` and `CalledProcessError` exceptions
- Added git clone error detection and reporting in `repository_actions.py`
- Added coverage combine failure detection to skip coverage loading if combine operation fails

### Bug Fixes
- Fixed race condition in `_search_size_range` by moving `processed_repos.add(full_name)` before repository processing instead of after, preventing duplicate processing if an error occurs
- Changed `continue` to `break` in `find_repaired_test_cases` when `move_to_later_commit()` fails, as continuing would be incorrect logic

### File I/O Improvements
- Implemented file locking using `fcntl` in `save_case` method to prevent concurrent write corruption when multiple processes write to the same CSV file
- Changed file existence check from `exists()` to checking file size (`st_size == 0`) for more reliable header writing
- Added `csv.QUOTE_ALL` to ensure proper CSV formatting with special characters
- Added cleanup of stale `.coverage*` files before running coverage to prevent data corruption from previous runs

## Implementation Details
- File locking uses exclusive locks (`fcntl.LOCK_EX`) during write operations with proper unlock in finally block
- Process termination now uses a two-stage approach: terminate with timeout, then kill if still alive
- Coverage file cleanup is wrapped in try-except to gracefully handle permission issues

https://claude.ai/code/session_01A7fJzZDQr7GHKCAhN3f7VB