### PR TITLE
Improve test case handling and add parametrized test filtering

### DIFF
--- a/repository_search/repository_actions.py
+++ b/repository_search/repository_actions.py
@@ -209,7 +209,7 @@ class RepositoryActions:
                 # ---------- override must FAIL ----------
                 overridden = self.run_test_with_overridden_test_code(rel_path, test_method, parent_methods[key])
 
-                if overridden.status == TestVerdict.FAILURE:
+                if overridden.status in (TestVerdict.FAILURE, TestVerdict.SYNTAX_ERR):
                     repaired_cases.add(
                         Broken_to_repaired(parent_commit, self.current_hash, test_method, rel_path, overridden.log)
                     )
@@ -247,6 +247,9 @@ class RepositoryActions:
             broken_to_repaired_instance.broken,
             broken_to_repaired_instance.repaired
         )
+
+        if not source_code:
+            return "Error"
 
         annotated_code = self.annotate_code(broken_test, repaired_test, source_code, broken_to_repaired_instance.rel_path)
         return annotated_code
@@ -418,6 +421,8 @@ class RepositoryActions:
         test_methods = []
         for node in ast.walk(tree):
             if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name.startswith("test_"):
+                if any("parametrize" in (ast.get_source_segment(source, d) or "") for d in node.decorator_list):
+                    continue
                 test_methods.append([test_rel_path, node.name])
         for node in ast.walk(tree):
             if isinstance(node, ast.ClassDef):


### PR DESCRIPTION
## Summary
This PR improves the robustness of test case analysis by handling additional test verdict states, adding null-safety checks, and filtering out parametrized tests from test method detection.

## Key Changes
- **Extended test verdict handling**: Modified `find_repaired_test_cases()` to recognize both `TestVerdict.FAILURE` and `TestVerdict.SYNTAX_ERR` as valid repaired test cases, allowing syntax errors to be treated as successful repairs
- **Added null-safety check**: Added a guard clause in `extract_and_annotate_code()` to return early with an error message if source code extraction fails, preventing downstream errors
- **Parametrized test filtering**: Updated `find_test_methods()` to skip test methods decorated with `@parametrize`, as these require special handling and should not be processed as regular test methods

## Implementation Details
- The syntax error handling change recognizes that syntax errors in overridden test code can indicate successful test repairs
- The source code null check prevents attempting to annotate code when extraction fails
- Parametrized test detection uses AST decorator inspection to identify and exclude tests that use pytest's parametrize decorator

https://claude.ai/code/session_01WJumkt7k1jbt3WYpLKQY7V