### PR TITLE
Add setup scripts for virtual environment initialization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /venv/
+/transformers/

--- a/setup_venv.ps1
+++ b/setup_venv.ps1
@@ -1,0 +1,105 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+    Create and populate a virtual environment for PyTaRGET.
+.PARAMETER DeepSeek
+    Also clone and install HuggingFace/transformers from source (required for DeepSeek support).
+#>
+param([switch]$DeepSeek)
+
+$ErrorActionPreference = 'Stop'
+$ScriptDir  = $PSScriptRoot
+$VenvDir    = Join-Path $ScriptDir 'venv'
+
+# ── find Python 3.12+ ────────────────────────────────────────────────────────
+function Find-Python312 {
+    # Try the Windows Python Launcher with explicit version flags first
+    foreach ($ver in '3.13', '3.12') {
+        try {
+            $null = & py "-$ver" --version 2>&1
+            if ($LASTEXITCODE -eq 0) { return "py -$ver" }
+        } catch {}
+    }
+    # Fall back to bare executables
+    foreach ($cmd in 'python3.13', 'python3.12', 'python3', 'python') {
+        try {
+            $null = & $cmd --version 2>&1
+            if ($LASTEXITCODE -ne 0) { continue }
+            $ok = & $cmd -c "import sys; exit(0 if sys.version_info>=(3,12) else 1)" 2>&1
+            if ($LASTEXITCODE -eq 0) { return $cmd }
+        } catch {}
+    }
+    return $null
+}
+
+$PythonCmd = Find-Python312
+if (-not $PythonCmd) {
+    Write-Error "Python 3.12+ not found. Install it from https://python.org and ensure it is on your PATH."
+    exit 1
+}
+
+# Split into executable + args so we can call it properly
+$PythonParts = $PythonCmd -split ' '
+$PyExe  = $PythonParts[0]
+$PyArgs = $PythonParts[1..($PythonParts.Length - 1)]
+
+$version = & $PyExe @PyArgs --version
+Write-Host "Python : $version  ($PythonCmd)"
+
+# ── create venv ──────────────────────────────────────────────────────────────
+if (Test-Path $VenvDir) {
+    Write-Host "Venv   : already exists at $VenvDir (skipping creation)"
+    Write-Host "         Delete it first if you want a clean rebuild:  Remove-Item -Recurse -Force $VenvDir"
+} else {
+    Write-Host "Venv   : creating at $VenvDir"
+    & $PyExe @PyArgs -m venv $VenvDir
+}
+
+$Pip    = Join-Path $VenvDir 'Scripts\pip.exe'
+$Python = Join-Path $VenvDir 'Scripts\python.exe'
+
+# ── install dependencies ─────────────────────────────────────────────────────
+Write-Host ""
+Write-Host "Installing requirements.txt ..."
+& $Pip install --upgrade pip --quiet
+& $Pip install -r (Join-Path $ScriptDir 'requirements.txt')
+
+Write-Host ""
+Write-Host "Pinning tree-sitter==0.24.0 (conflict warnings below are expected) ..."
+& $Pip install tree-sitter==0.24.0
+
+# ── optional: DeepSeek transformers ──────────────────────────────────────────
+if ($DeepSeek) {
+    Write-Host ""
+    Write-Host "DeepSeek: cloning HuggingFace/transformers from source ..."
+    $TransformersDir = Join-Path $ScriptDir 'transformers'
+    if (Test-Path $TransformersDir) {
+        Write-Host "  Directory already exists, pulling latest ..."
+        git -C $TransformersDir pull --ff-only
+    } else {
+        git clone --depth 1 https://github.com/huggingface/transformers.git $TransformersDir
+    }
+    Write-Host "  Installing in editable mode ..."
+    & $Pip install -e $TransformersDir
+}
+
+# ── done ─────────────────────────────────────────────────────────────────────
+$ParentDir = Split-Path $ScriptDir -Parent
+$ActivatePath = Join-Path $VenvDir 'Scripts\Activate.ps1'
+
+Write-Host ""
+Write-Host ("=" * 57)
+Write-Host "Setup complete."
+Write-Host ""
+Write-Host "Activate:"
+Write-Host "  & '$ActivatePath'"
+Write-Host ""
+Write-Host "Run code from the PARENT directory of PyTaRGET:"
+Write-Host "  cd $ParentDir"
+Write-Host "  python -c 'from PyTaRGET.data_processing.encode_tune_test import Eftt'"
+Write-Host ""
+if (-not $DeepSeek) {
+    Write-Host "For DeepSeek support, re-run with:  .\setup_venv.ps1 -DeepSeek"
+    Write-Host ""
+}
+Write-Host ("=" * 57)

--- a/setup_venv.sh
+++ b/setup_venv.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+VENV_DIR="$SCRIPT_DIR/venv"
+DEEPSEEK=0
+
+usage() {
+    echo "Usage: $0 [--deepseek]"
+    echo ""
+    echo "  --deepseek   Also clone and install HuggingFace/transformers from source"
+    echo "               (required for DeepSeek model support)"
+    exit 0
+}
+
+for arg in "$@"; do
+    case "$arg" in
+        --deepseek) DEEPSEEK=1 ;;
+        -h|--help)  usage ;;
+        *) echo "Unknown argument: $arg"; usage ;;
+    esac
+done
+
+# ── find Python 3.12+ ────────────────────────────────────────────────────────
+find_python() {
+    for cmd in python3.13 python3.12 python3 python; do
+        if command -v "$cmd" &>/dev/null; then
+            if "$cmd" -c "import sys; sys.exit(0 if sys.version_info >= (3,12) else 1)" 2>/dev/null; then
+                echo "$cmd"
+                return 0
+            fi
+        fi
+    done
+    return 1
+}
+
+PYTHON=$(find_python) || {
+    echo "ERROR: Python 3.12+ not found."
+    echo "Install it and make sure it is on your PATH, then re-run this script."
+    exit 1
+}
+echo "Python : $($PYTHON --version) ($PYTHON)"
+
+# ── create venv ──────────────────────────────────────────────────────────────
+if [ -d "$VENV_DIR" ]; then
+    echo "Venv   : already exists at $VENV_DIR (skipping creation)"
+    echo "         Delete it first if you want a clean rebuild: rm -rf $VENV_DIR"
+else
+    echo "Venv   : creating at $VENV_DIR"
+    "$PYTHON" -m venv "$VENV_DIR"
+fi
+
+PIP="$VENV_DIR/bin/pip"
+PYTHON_VENV="$VENV_DIR/bin/python"
+
+# ── install dependencies ─────────────────────────────────────────────────────
+echo ""
+echo "Installing requirements.txt ..."
+"$PIP" install --upgrade pip --quiet
+"$PIP" install -r "$SCRIPT_DIR/requirements.txt"
+
+# tree-sitter must be exactly 0.24.0; pip warns about conflicts — that is expected
+echo ""
+echo "Pinning tree-sitter==0.24.0 (conflict warnings below are expected) ..."
+"$PIP" install tree-sitter==0.24.0
+
+# ── optional: DeepSeek transformers ──────────────────────────────────────────
+if [ "$DEEPSEEK" -eq 1 ]; then
+    echo ""
+    echo "DeepSeek: cloning HuggingFace/transformers from source ..."
+    TRANSFORMERS_DIR="$SCRIPT_DIR/transformers"
+    if [ -d "$TRANSFORMERS_DIR" ]; then
+        echo "  Directory $TRANSFORMERS_DIR already exists, pulling latest ..."
+        git -C "$TRANSFORMERS_DIR" pull --ff-only
+    else
+        git clone --depth 1 https://github.com/huggingface/transformers.git "$TRANSFORMERS_DIR"
+    fi
+    echo "  Installing in editable mode ..."
+    "$PIP" install -e "$TRANSFORMERS_DIR"
+fi
+
+# ── done ─────────────────────────────────────────────────────────────────────
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "Setup complete."
+echo ""
+echo "Activate:"
+echo "  source $VENV_DIR/bin/activate"
+echo ""
+echo "Run code from the PARENT directory of PyTaRGET:"
+echo "  cd $(dirname "$SCRIPT_DIR")"
+echo "  python -c 'from PyTaRGET.data_processing.encode_tune_test import Eftt'"
+echo ""
+if [ "$DEEPSEEK" -eq 0 ]; then
+    echo "For DeepSeek support, re-run with:  $0 --deepseek"
+    echo ""
+fi
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"


### PR DESCRIPTION
## Summary
Add cross-platform setup scripts to automate virtual environment creation and dependency installation for PyTaRGET. This provides a streamlined onboarding experience for both Windows (PowerShell) and Unix-like systems (Bash).

## Key Changes
- **setup_venv.ps1**: PowerShell script for Windows that:
  - Detects Python 3.12+ using the Windows Python Launcher and fallback methods
  - Creates and populates a virtual environment
  - Installs dependencies from requirements.txt
  - Pins tree-sitter to version 0.24.0 (with expected conflict warnings)
  - Optionally clones and installs HuggingFace/transformers from source for DeepSeek support via `-DeepSeek` flag

- **setup_venv.sh**: Bash script for macOS/Linux with equivalent functionality:
  - Detects Python 3.12+ from standard command names
  - Creates virtual environment and installs dependencies
  - Supports `--deepseek` flag for optional transformers installation
  - Uses standard Unix conventions and error handling

- **.gitignore**: Updated to ignore the optional `/transformers/` directory created when DeepSeek support is enabled

## Notable Implementation Details
- Both scripts use robust Python version detection with fallback strategies
- Scripts skip venv recreation if one already exists, with clear instructions for clean rebuilds
- Helpful post-setup instructions guide users to activate the environment and run code from the parent directory
- DeepSeek transformers installation uses shallow cloning (`--depth 1`) and editable mode for development
- Consistent messaging and formatting across both platforms for user experience

https://claude.ai/code/session_0197o3uutR3AnJmXtnPJ7vY4