### PR TITLE
Improve pip install output handling and reduce verbosity

### DIFF
--- a/repository_search/GitHubSearch.py
+++ b/repository_search/GitHubSearch.py
@@ -256,7 +256,12 @@ def run_processor_in_venv(full_name, repository_path, out_path, venv_path):
 
     miner = root / "repository_search" / "main_repository_miner.py"
 
-    subprocess.run([python_bin, "-m", "pip", "install", "pytest", "coverage"], timeout=600, check=False)
+    subprocess.run(
+        [python_bin, "-m", "pip", "install", "-q", "--disable-pip-version-check", "pytest", "coverage"],
+        timeout=600,
+        check=False,
+        capture_output=True,
+    )
 
     subprocess.check_call([
         python_bin, "-u", str(miner),

--- a/repository_search/repository_actions.py
+++ b/repository_search/repository_actions.py
@@ -51,8 +51,10 @@ class RepositoryActions:
         cmd = ["git", "clone", repo_url, dest_dir]
         subprocess.run(cmd, capture_output=True, text=True, env=os.environ)
 
-        cmd = [sys.executable, "-m", "pip", "install", "."]
-        print(subprocess.run(cmd, capture_output=True, text=True, env=os.environ, cwd=dest_dir))
+        cmd = [sys.executable, "-m", "pip", "install", "-q", "--disable-pip-version-check", "."]
+        result = subprocess.run(cmd, capture_output=True, text=True, env=os.environ, cwd=dest_dir)
+        if result.returncode != 0:
+            print(f"Warning: pip install failed for {self.repository_name}:\n{result.stderr.strip()}")
 
         hash_cmd = ["git", "rev-parse", "HEAD"]
         hash_result = subprocess.run(hash_cmd, cwd=dest_dir, capture_output=True, text=True, env=os.environ)


### PR DESCRIPTION
## Summary
This PR improves the handling of pip install commands by reducing output verbosity and adding better error reporting when installations fail.

## Key Changes
- **Reduced pip output**: Added `-q` (quiet) and `--disable-pip-version-check` flags to pip install commands in both `GitHubSearch.py` and `repository_actions.py` to suppress unnecessary output
- **Better error handling**: Modified `repository_actions.py` to capture the return code from pip install and only print a warning message if the installation fails, rather than always printing the full subprocess result object
- **Improved logging**: Changed from printing the raw subprocess result object to printing a formatted warning message that includes the repository name and stderr output when pip install fails

## Implementation Details
- In `GitHubSearch.py`: Reformatted the pip install subprocess call for better readability and added `capture_output=True` to suppress output
- In `repository_actions.py`: Added conditional error reporting that checks `result.returncode` and only logs failures with relevant context (repository name and error message), making the output cleaner during successful installations

https://claude.ai/code/session_01WbVYsLo4hkdyGv5SxNo4SF