### PR TITLE
Add comprehensive test suite for repository_search module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 /venv/
 /transformers/
+__pycache__/
+*.pyc
+.pytest_cache/

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+testpaths = tests
+addopts = -ra
+filterwarnings =
+    ignore::DeprecationWarning

--- a/repository_search/repository_actions.py
+++ b/repository_search/repository_actions.py
@@ -111,13 +111,33 @@ class RepositoryActions:
             test_file_path.write_text(new_content, encoding="utf-8")
 
             self.repo_dir = Path(self.repository_path) / self.repository_name.split("/")[-1]
+            # Invalidate cached bytecode before running. The overridden test is
+            # frequently the same byte-size as the child test it replaces and is
+            # written within the same wall-clock second, so the .pyc header
+            # (source mtime at second resolution + size) still matches the
+            # stale, child-version bytecode. Without this, Python/pytest reuse
+            # that stale bytecode and the override spuriously *passes*, causing
+            # every genuine repaired case to be silently discarded.
+            self._invalidate_bytecode_cache()
             result = compile_and_run_test_python(
                 self.repo_dir, rel_path, test_method, self.repo_dir.parent
             )
         finally:
             test_file_path.write_text(original_content, encoding="utf-8")
+            self._invalidate_bytecode_cache()
 
         return result
+
+    def _invalidate_bytecode_cache(self):
+        """Remove cached bytecode under the repo so freshly written test source
+        is always recompiled (see run_test_with_overridden_test_code)."""
+        for cache_dir in self.repo_dir.rglob("__pycache__"):
+            shutil.rmtree(cache_dir, ignore_errors=True)
+        for pyc in self.repo_dir.rglob("*.pyc"):
+            try:
+                pyc.unlink()
+            except OSError:
+                pass
 
     def find_repaired_test_cases(self):
         """
@@ -671,6 +691,12 @@ class RepositoryActions:
         if proc.returncode != 0:
             print(f"Git checkout failed: {proc.stderr}")
             return None
+
+        # Checking out broken/repaired commits in place can leave stale .pyc
+        # files whose header (source mtime at second resolution + size) still
+        # matches the just-checked-out source, so coverage would measure the
+        # previous commit's bytecode and yield wrong/empty covered source.
+        self._invalidate_bytecode_cache()
 
         # Ensure a .coveragerc file exists.
         coveragerc_path = self.repo_dir / ".coveragerc"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,114 @@
+"""Shared pytest fixtures and path setup for the repository_search test suite.
+
+The production code mixes two import roots:
+
+* ``repository_actions`` does ``from data_types.Broken_to_repaired import ...``
+  (resolved from the project root) and ``from py_parser import ...``
+  (resolved from inside ``repository_search/``).
+* ``main_repository_miner`` does ``import repository_actions`` (also resolved
+  from inside ``repository_search/``).
+
+So both the project root *and* ``repository_search/`` must be importable.
+"""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent
+REPO_SEARCH = ROOT / "repository_search"
+
+for p in (str(ROOT), str(REPO_SEARCH)):
+    if p not in sys.path:
+        sys.path.insert(0, p)
+
+
+# --------------------------------------------------------------------------- #
+#  Git / network availability                                                 #
+# --------------------------------------------------------------------------- #
+def _git_present():
+    try:
+        subprocess.run(["git", "--version"], capture_output=True, check=True)
+        return True
+    except Exception:
+        return False
+
+
+GIT_AVAILABLE = _git_present()
+
+
+@pytest.fixture(scope="session")
+def git_available():
+    if not GIT_AVAILABLE:
+        pytest.skip("git executable not available")
+    return True
+
+
+# A small, stable, well-known repository used to exercise the real git
+# operations.  Pinned SHAs taken from its public, immutable history so the
+# tests are deterministic.
+SIX_REPO_URL = "https://github.com/benjaminp/six.git"
+SIX_REPO_NAME = "benjaminp/six"
+
+# Linear chain on master:  HEAD -> PARENT -> GRANDPARENT
+SIX_SHA_HEAD = "65486e4383f9f411da95937451205d3c7b61b9e1"
+SIX_SHA_PARENT = "1a4f325d55b10541ea94b889cda01e6281ba1689"
+SIX_SHA_GRANDPARENT = "64601c7c016227aad81855031d88edb5cba17799"
+
+
+@pytest.fixture(scope="session")
+def six_clone(git_available, tmp_path_factory):
+    """Clone the pinned well-known repo once per test session.
+
+    Returns ``(repository_path, repository_name)`` such that the working tree
+    lives at ``repository_path/six`` -- exactly the layout
+    ``RepositoryActions`` expects (``repo_dir = repository_path/<repo-name>``).
+    """
+    base = tmp_path_factory.mktemp("six_session")
+    dest = base / "six"
+    result = subprocess.run(
+        ["git", "clone", SIX_REPO_URL, str(dest)],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        pytest.skip(f"network unavailable - git clone failed: {result.stderr.strip()}")
+    # Make sure the pinned SHAs are actually present (full clone, not shallow).
+    check = subprocess.run(
+        ["git", "cat-file", "-e", SIX_SHA_HEAD],
+        cwd=str(dest), capture_output=True,
+    )
+    if check.returncode != 0:
+        pytest.skip("pinned commit not present in clone")
+    return str(base), SIX_REPO_NAME
+
+
+# --------------------------------------------------------------------------- #
+#  Helpers for the pure / internal repository_actions tests                   #
+# --------------------------------------------------------------------------- #
+@pytest.fixture
+def make_actions(tmp_path):
+    """Factory that builds a RepositoryActions over a fake on-disk repo.
+
+    ``files`` maps a repo-relative path -> file contents.  The fake repo is
+    created at ``<tmp>/proj`` to match ``repository_name='owner/proj'``.
+    """
+    import repository_actions
+
+    def _factory(files=None, repository_name="owner/proj"):
+        repo_root = tmp_path
+        work = repo_root / repository_name.split("/")[-1]
+        work.mkdir(parents=True, exist_ok=True)
+        for rel, content in (files or {}).items():
+            target = work / rel
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(content, encoding="utf-8")
+        return repository_actions.RepositoryActions(
+            repository_name=repository_name,
+            repository_path=str(repo_root),
+        )
+
+    return _factory

--- a/tests/test_find_repaired_cases_integration.py
+++ b/tests/test_find_repaired_cases_integration.py
@@ -1,0 +1,125 @@
+"""End-to-end test of RepositoryActions.find_repaired_test_cases().
+
+This is the heart of the miner and the most likely place for "no cases found"
+to originate, so it is exercised against a *real* (but tiny, local) git repo
+that contains a genuine broken->repaired scenario:
+
+    parent commit:  f() returns 1,  test asserts f() == 1   (passes)
+    child  commit:  f() returns 2,  test asserts f() == 2   (passes)
+    override:       child's f() (==2) + parent's test (==1)  -> FAILS
+
+That triple is exactly what find_repaired_test_cases looks for, so it must
+surface one repaired case.  The test file is self-contained (the function
+under test lives in the same file) so no ``pip install`` of the repo is needed.
+"""
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+import repository_actions
+
+
+PARENT_FILE = (
+    "def f():\n"
+    "    return 1\n"
+    "\n"
+    "def test_f():\n"
+    "    assert f() == 1\n"
+)
+
+CHILD_FILE = (
+    "def f():\n"
+    "    return 2\n"
+    "\n"
+    "def test_f():\n"
+    "    assert f() == 2\n"
+)
+
+
+def _git(args, cwd, **kw):
+    return subprocess.run(["git", *args], cwd=str(cwd), capture_output=True,
+                          text=True, check=True, **kw)
+
+
+@pytest.fixture
+def broken_repaired_repo(git_available, tmp_path):
+    """Build <tmp>/proj as a git repo with a parent->child repair scenario."""
+    base = tmp_path
+    work = base / "proj"
+    tests_dir = work / "tests"
+    tests_dir.mkdir(parents=True)
+
+    _git(["init", "-q"], cwd=work)
+    _git(["config", "user.email", "t@example.com"], cwd=work)
+    _git(["config", "user.name", "Tester"], cwd=work)
+    _git(["config", "commit.gpgsign", "false"], cwd=work)
+
+    test_file = tests_dir / "test_mod.py"
+
+    # --- parent commit ---
+    test_file.write_text(PARENT_FILE, encoding="utf-8")
+    _git(["add", "-A"], cwd=work)
+    _git(["commit", "-q", "-m", "parent"], cwd=work)
+    parent_sha = _git(["rev-parse", "HEAD"], cwd=work).stdout.strip()
+
+    # --- child commit (modifies the test file) ---
+    test_file.write_text(CHILD_FILE, encoding="utf-8")
+    _git(["add", "-A"], cwd=work)
+    _git(["commit", "-q", "-m", "child"], cwd=work)
+    child_sha = _git(["rev-parse", "HEAD"], cwd=work).stdout.strip()
+
+    return str(base), parent_sha, child_sha
+
+
+def test_find_repaired_test_cases_surfaces_the_repair(broken_repaired_repo):
+    repository_path, parent_sha, child_sha = broken_repaired_repo
+
+    a = repository_actions.RepositoryActions("local/proj", repository_path)
+    a.current_hash = child_sha
+    a.visited_commits = set()
+
+    cases = a.find_repaired_test_cases()
+
+    assert len(cases) == 1, f"expected exactly one repaired case, got {cases}"
+    case = next(iter(cases))
+    assert case.test_name == "test_f"
+    assert case.rel_path.replace("\\", "/") == "tests/test_mod.py"
+    assert case.broken == parent_sha
+    assert case.repaired == child_sha
+
+
+def test_no_case_when_test_unchanged(git_available, tmp_path):
+    """If the test method does not change between commits, nothing is found.
+
+    This guards the upstream gate: only *changed* test methods are candidates,
+    so a source-only change must not produce a spurious repaired case.
+    """
+    work = tmp_path / "proj"
+    tests_dir = work / "tests"
+    tests_dir.mkdir(parents=True)
+    _git(["init", "-q"], cwd=work)
+    _git(["config", "user.email", "t@example.com"], cwd=work)
+    _git(["config", "user.name", "Tester"], cwd=work)
+    _git(["config", "commit.gpgsign", "false"], cwd=work)
+
+    test_file = tests_dir / "test_mod.py"
+    # test method identical in both commits; only a comment differs
+    v1 = "def test_f():\n    assert 1 == 1\n"
+    v2 = "# changed comment\ndef test_f():\n    assert 1 == 1\n"
+
+    test_file.write_text(v1, encoding="utf-8")
+    _git(["add", "-A"], cwd=work)
+    _git(["commit", "-q", "-m", "p"], cwd=work)
+
+    test_file.write_text(v2, encoding="utf-8")
+    _git(["add", "-A"], cwd=work)
+    _git(["commit", "-q", "-m", "c"], cwd=work)
+    child_sha = _git(["rev-parse", "HEAD"], cwd=work).stdout.strip()
+
+    a = repository_actions.RepositoryActions("local/proj", str(tmp_path))
+    a.current_hash = child_sha
+    a.visited_commits = set()
+
+    assert a.find_repaired_test_cases() == set()

--- a/tests/test_github_search.py
+++ b/tests/test_github_search.py
@@ -1,0 +1,356 @@
+"""Tests for repository_search/GitHubSearch.py.
+
+All network (`requests`), sleeping (`time.sleep`), subprocess, multiprocessing
+and venv interactions are stubbed so the search/orchestration logic is tested
+deterministically and offline.
+"""
+
+import os
+
+import pytest
+
+import GitHubSearch
+from GitHubSearch import GitHubSearch as GHS
+
+
+# --------------------------------------------------------------------------- #
+#  Fakes                                                                      #
+# --------------------------------------------------------------------------- #
+class FakeResponse:
+    def __init__(self, status_code=200, json_data=None, headers=None, links=None):
+        self.status_code = status_code
+        self._json = json_data or {}
+        self.headers = headers or {}
+        self.links = links or {}
+
+    def json(self):
+        return self._json
+
+
+@pytest.fixture(autouse=True)
+def no_sleep(monkeypatch):
+    """Never actually sleep in any GitHubSearch test."""
+    monkeypatch.setattr(GitHubSearch.time, "sleep", lambda *_a, **_k: None)
+
+
+def make_searcher(tmp_path, version="v1"):
+    return GHS(github_token="tok", version=version, cwd=str(tmp_path))
+
+
+# --------------------------------------------------------------------------- #
+#  __init__ path derivation                                                   #
+# --------------------------------------------------------------------------- #
+class TestInit:
+    def test_version_mode_paths(self, tmp_path):
+        s = make_searcher(tmp_path, "exp")
+        assert s.output_csv == tmp_path / "annotated_cases_exp.csv"
+        assert s.processed_file == tmp_path / "processed_repositories_exp.txt"
+        assert s.repository_path == str(tmp_path / "repos_exp")
+
+    def test_deprecated_mode_warns(self, tmp_path):
+        with pytest.warns(DeprecationWarning):
+            s = GHS(github_token="tok", out_path=str(tmp_path), repository_path="rp")
+        assert s.output_csv == tmp_path / "annotated_cases.csv"
+
+
+# --------------------------------------------------------------------------- #
+#  get_latest_commit                                                          #
+# --------------------------------------------------------------------------- #
+class TestGetLatestCommit:
+    def test_returns_sha(self, tmp_path, monkeypatch):
+        s = make_searcher(tmp_path)
+        monkeypatch.setattr(GitHubSearch.requests, "get",
+                            lambda *a, **k: FakeResponse(200, [{"sha": "abc123"}]))
+        assert s.get_latest_commit("o/r") == "abc123"
+
+    def test_empty_on_non_200(self, tmp_path, monkeypatch):
+        s = make_searcher(tmp_path)
+        monkeypatch.setattr(GitHubSearch.requests, "get",
+                            lambda *a, **k: FakeResponse(404, {}))
+        assert s.get_latest_commit("o/r") == ""
+
+    def test_empty_on_empty_list(self, tmp_path, monkeypatch):
+        s = make_searcher(tmp_path)
+        monkeypatch.setattr(GitHubSearch.requests, "get",
+                            lambda *a, **k: FakeResponse(200, []))
+        assert s.get_latest_commit("o/r") == ""
+
+
+# --------------------------------------------------------------------------- #
+#  _rate_limit_sleep                                                          #
+# --------------------------------------------------------------------------- #
+class TestRateLimitSleep:
+    def test_long_wait_when_exhausted(self, tmp_path, monkeypatch):
+        s = make_searcher(tmp_path)
+        slept = []
+        monkeypatch.setattr(GitHubSearch.time, "sleep", lambda n: slept.append(n))
+        monkeypatch.setattr(GitHubSearch.time, "time", lambda: 1000)
+        resp = FakeResponse(headers={"X-RateLimit-Remaining": "1", "X-RateLimit-Reset": "1010"})
+        s._rate_limit_sleep(resp)
+        assert slept and slept[0] >= 10
+
+    def test_short_wait_when_plenty(self, tmp_path, monkeypatch):
+        s = make_searcher(tmp_path)
+        slept = []
+        monkeypatch.setattr(GitHubSearch.time, "sleep", lambda n: slept.append(n))
+        resp = FakeResponse(headers={"X-RateLimit-Remaining": "100"})
+        s._rate_limit_sleep(resp)
+        assert slept == [2]
+
+
+# --------------------------------------------------------------------------- #
+#  _github_search_request                                                     #
+# --------------------------------------------------------------------------- #
+class TestGithubSearchRequest:
+    def test_returns_on_200(self, tmp_path, monkeypatch):
+        s = make_searcher(tmp_path)
+        ok = FakeResponse(200, {"total_count": 0})
+        monkeypatch.setattr(GitHubSearch.requests, "get", lambda *a, **k: ok)
+        assert s._github_search_request({}, {}) is ok
+
+    def test_retries_after_rate_limit_then_succeeds(self, tmp_path, monkeypatch):
+        s = make_searcher(tmp_path)
+        seq = [FakeResponse(403, headers={"Retry-After": "1"}),
+               FakeResponse(200, {"total_count": 1})]
+        calls = iter(seq)
+        monkeypatch.setattr(GitHubSearch.requests, "get", lambda *a, **k: next(calls))
+        result = s._github_search_request({}, {})
+        assert result.status_code == 200
+
+    def test_returns_none_after_exhausting_retries(self, tmp_path, monkeypatch):
+        s = make_searcher(tmp_path)
+        monkeypatch.setattr(GitHubSearch.requests, "get",
+                            lambda *a, **k: FakeResponse(500, {}))
+        assert s._github_search_request({}, {}, retries=2) is None
+
+
+# --------------------------------------------------------------------------- #
+#  _search_size_range                                                         #
+# --------------------------------------------------------------------------- #
+class TestSearchSizeRange:
+    def test_zero_total_count_processes_nothing(self, tmp_path, monkeypatch):
+        s = make_searcher(tmp_path)
+        s._run_count = 0
+        monkeypatch.setattr(s, "_github_search_request",
+                            lambda h, p, **k: FakeResponse(200, {"total_count": 0}))
+        processed = set()
+        called = []
+        monkeypatch.setattr(s, "process_repository_with_timeout",
+                            lambda fn: called.append(fn))
+        s._search_size_range("q", 0, 100, {}, processed)
+        assert called == []
+
+    def test_splits_range_when_over_1000(self, tmp_path, monkeypatch):
+        s = make_searcher(tmp_path)
+        s._run_count = 0
+        queries = []
+
+        def fake_request(headers, params, **k):
+            q = params["q"]
+            queries.append(q)
+            # Only the original full range is "too big"; sub-ranges are empty.
+            if "size:>=0 size:<100" in q:
+                return FakeResponse(200, {"total_count": 1000, "items": []})
+            return FakeResponse(200, {"total_count": 0})
+
+        monkeypatch.setattr(s, "_github_search_request", fake_request)
+        monkeypatch.setattr(s, "process_repository_with_timeout", lambda fn: True)
+        s._search_size_range("q", 0, 100, {}, set())
+
+        # Recursion split into [0,50) and [50,100).
+        assert any("size:>=0 size:<50" in q for q in queries)
+        assert any("size:>=50 size:<100" in q for q in queries)
+
+    def test_processes_items_and_writes_blacklist(self, tmp_path, monkeypatch):
+        s = make_searcher(tmp_path)
+        s._run_count = 0
+        resp = FakeResponse(200, {
+            "total_count": 2,
+            "items": [{"full_name": "o/already"}, {"full_name": "o/new"}],
+        }, links={})  # no 'next' -> single page
+        monkeypatch.setattr(s, "_github_search_request", lambda h, p, **k: resp)
+
+        processed_calls = []
+        monkeypatch.setattr(s, "process_repository_with_timeout",
+                            lambda fn: processed_calls.append(fn) or True)
+        monkeypatch.setattr(s, "get_latest_commit", lambda fn: "sha-" + fn.split("/")[-1])
+        monkeypatch.setattr(s, "run_pytest_check", lambda fn: None)
+
+        processed = {"o/already"}  # pre-seeded -> should be skipped
+        s._search_size_range("q", 0, 100, {}, processed)
+
+        # Only the not-yet-seen repo is processed.
+        assert processed_calls == ["o/new"]
+        assert "o/new" in processed
+        assert s._run_count == 1
+
+        blacklist = s.processed_file.read_text(encoding="utf-8")
+        assert "o/new|sha-new" in blacklist
+
+
+# --------------------------------------------------------------------------- #
+#  find_and_process_repositories (resume / blacklist reading)                 #
+# --------------------------------------------------------------------------- #
+class TestFindAndProcess:
+    def test_resumes_from_blacklist(self, tmp_path, monkeypatch):
+        s = make_searcher(tmp_path)
+        s.processed_file.write_text("o/old|deadbeef\n", encoding="utf-8")
+
+        captured = {}
+
+        def fake_range(query_base, ss, se, headers, processed_repos):
+            captured["processed"] = set(processed_repos)
+
+        monkeypatch.setattr(s, "_search_size_range", fake_range)
+        s.find_and_process_repositories()
+
+        assert "o/old" in captured["processed"]
+        assert s._run_count == 0
+
+    def test_counts_found_cases_from_csv(self, tmp_path, monkeypatch, capsys):
+        s = make_searcher(tmp_path)
+        s.output_csv.write_text("header\nrow1\nrow2\n", encoding="utf-8")
+        monkeypatch.setattr(s, "_search_size_range", lambda *a, **k: None)
+        s.find_and_process_repositories()
+        out = capsys.readouterr().out
+        assert "found 2 test cases" in out
+
+
+# --------------------------------------------------------------------------- #
+#  run_pytest_check / reinstall_pytest / run_pytest_trace                     #
+# --------------------------------------------------------------------------- #
+class _Proc:
+    def __init__(self, returncode, stdout="", stderr=""):
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+class TestPytestCheck:
+    def test_ok_returncode_returns_quietly(self, tmp_path, monkeypatch):
+        s = make_searcher(tmp_path)
+        monkeypatch.setattr(s, "run_pytest_trace", lambda: _Proc(0))
+        assert s.run_pytest_check("o/r") is None
+
+    def test_no_tests_returncode_5_is_ok(self, tmp_path, monkeypatch):
+        s = make_searcher(tmp_path)
+        monkeypatch.setattr(s, "run_pytest_trace", lambda: _Proc(5))
+        assert s.run_pytest_check("o/r") is None
+
+    def test_persistent_failure_exits(self, tmp_path, monkeypatch):
+        s = make_searcher(tmp_path)
+        monkeypatch.setattr(s, "run_pytest_trace", lambda: _Proc(1, "out", "err"))
+        monkeypatch.setattr(s, "reinstall_pytest", lambda: None)
+        with pytest.raises(SystemExit):
+            s.run_pytest_check("o/r")
+
+    def test_reinstall_runs_uninstall_then_install(self, tmp_path, monkeypatch):
+        s = make_searcher(tmp_path)
+        cmds = []
+        monkeypatch.setattr(GitHubSearch.subprocess, "run",
+                            lambda cmd, **k: cmds.append(cmd) or _Proc(0))
+        s.reinstall_pytest()
+        assert any("uninstall" in c for c in cmds)
+        assert any("install" in c for c in cmds)
+
+    def test_run_pytest_trace_invokes_subprocess(self, tmp_path, monkeypatch):
+        s = make_searcher(tmp_path)
+        sentinel = _Proc(0)
+        monkeypatch.setattr(GitHubSearch.subprocess, "run", lambda *a, **k: sentinel)
+        assert s.run_pytest_trace() is sentinel
+
+
+# --------------------------------------------------------------------------- #
+#  process_repository_with_timeout                                            #
+# --------------------------------------------------------------------------- #
+class FakeProcess:
+    def __init__(self, target, args, alive=False, exitcode=0):
+        self.target = target
+        self.args = args
+        self._alive = alive
+        self.exitcode = exitcode
+        self.started = False
+
+    def start(self):
+        self.started = True
+
+    def join(self, timeout=None):
+        pass
+
+    def is_alive(self):
+        return self._alive
+
+    def terminate(self):
+        self._alive = False
+
+    def kill(self):
+        self._alive = False
+
+
+class TestProcessRepositoryWithTimeout:
+    def _patch_common(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(GitHubSearch, "create_virtualenv", lambda p: None)
+        monkeypatch.setattr(GitHubSearch.tempfile, "mkdtemp",
+                            lambda **k: str(tmp_path / "venv"))
+        monkeypatch.setattr(GitHubSearch.shutil, "rmtree", lambda *a, **k: None)
+
+    def test_success(self, tmp_path, monkeypatch):
+        s = make_searcher(tmp_path)
+        self._patch_common(monkeypatch, tmp_path)
+        monkeypatch.setattr(GitHubSearch.multiprocessing, "Process",
+                            lambda target, args: FakeProcess(target, args, alive=False, exitcode=0))
+        assert s.process_repository_with_timeout("o/r") is True
+
+    def test_nonzero_exit_is_failure(self, tmp_path, monkeypatch):
+        s = make_searcher(tmp_path)
+        self._patch_common(monkeypatch, tmp_path)
+        monkeypatch.setattr(GitHubSearch.multiprocessing, "Process",
+                            lambda target, args: FakeProcess(target, args, alive=False, exitcode=1))
+        assert s.process_repository_with_timeout("o/r") is False
+
+    def test_timeout_is_failure(self, tmp_path, monkeypatch):
+        s = make_searcher(tmp_path)
+        self._patch_common(monkeypatch, tmp_path)
+        monkeypatch.setattr(GitHubSearch.multiprocessing, "Process",
+                            lambda target, args: FakeProcess(target, args, alive=True, exitcode=None))
+        assert s.process_repository_with_timeout("o/r") is False
+
+
+# --------------------------------------------------------------------------- #
+#  module-level helpers                                                       #
+# --------------------------------------------------------------------------- #
+class TestModuleHelpers:
+    def test_create_virtualenv_uses_envbuilder(self, monkeypatch):
+        captured = {}
+
+        class FakeBuilder:
+            def __init__(self, **kwargs):
+                captured["kwargs"] = kwargs
+
+            def create(self, path):
+                captured["path"] = path
+
+        monkeypatch.setattr(GitHubSearch.venv, "EnvBuilder", FakeBuilder)
+        GitHubSearch.create_virtualenv("/some/venv")
+        assert captured["kwargs"] == {"with_pip": True, "clear": True}
+        assert captured["path"] == "/some/venv"
+
+    def test_run_processor_in_venv_builds_command_and_env(self, monkeypatch):
+        run_calls = []
+        check_calls = []
+        monkeypatch.setattr(GitHubSearch.subprocess, "run",
+                            lambda cmd, **k: run_calls.append((cmd, k)))
+        monkeypatch.setattr(GitHubSearch.subprocess, "check_call",
+                            lambda cmd, **k: check_calls.append((cmd, k)))
+
+        GitHubSearch.run_processor_in_venv("o/r", "/rp", "/out.csv", "/venv")
+
+        # pip install pytest/coverage happened.
+        assert any("install" in cmd for cmd, _ in run_calls)
+        # miner invoked with the right positional args.
+        miner_cmd, miner_kwargs = check_calls[0]
+        assert "o/r" in miner_cmd and "/rp" in miner_cmd and "/out.csv" in miner_cmd
+        assert miner_cmd[0].endswith(os.path.join("bin", "python")) or \
+               miner_cmd[0].endswith(os.path.join("Scripts", "python"))
+        # PYTHONPATH points at the project root.
+        assert "PYTHONPATH" in miner_kwargs["env"]

--- a/tests/test_main_repository_miner.py
+++ b/tests/test_main_repository_miner.py
@@ -1,0 +1,146 @@
+"""Tests for repository_search/main_repository_miner.py.
+
+The CSV writer (`save_case`) is tested for real; the orchestration in
+`process_repository` is tested by injecting a fake RepositoryActions so we
+exercise the control flow (has-tests gate, annotation skip, save) without git
+or the network.
+"""
+
+import csv
+
+import pytest
+
+import main_repository_miner
+from main_repository_miner import Main
+from data_types.Broken_to_repaired import Broken_to_repaired
+
+
+# --------------------------------------------------------------------------- #
+#  save_case                                                                  #
+# --------------------------------------------------------------------------- #
+class TestSaveCase:
+    def _read(self, path):
+        with path.open(encoding="utf-8") as fh:
+            return list(csv.reader(fh, delimiter="|"))
+
+    def test_writes_header_then_row(self, tmp_path):
+        csv_path = tmp_path / "out.csv"
+        m = Main("owner/proj", str(tmp_path), str(csv_path))
+        m.save_case("owner/proj", "ANNOT", "tests/test_a.py", "br0ken", "f1xed", "LOG")
+
+        rows = self._read(csv_path)
+        assert rows[0] == ["repository_name", "annotated_code", "relative_path",
+                           "broken_hash", "repaired_hash", "outdated_test_log"]
+        assert rows[1] == ["owner/proj", "ANNOT", "tests/test_a.py",
+                           "br0ken", "f1xed", "LOG"]
+
+    def test_appends_without_duplicate_header(self, tmp_path):
+        csv_path = tmp_path / "out.csv"
+        m = Main("owner/proj", str(tmp_path), str(csv_path))
+        m.save_case("owner/proj", "A1", "p1", "b1", "r1", "l1")
+        m.save_case("owner/proj", "A2", "p2", "b2", "r2", "l2")
+
+        rows = self._read(csv_path)
+        assert len(rows) == 3  # 1 header + 2 data rows
+        assert rows[1][1] == "A1"
+        assert rows[2][1] == "A2"
+
+    def test_preserves_embedded_pipes_and_newlines(self, tmp_path):
+        csv_path = tmp_path / "out.csv"
+        m = Main("owner/proj", str(tmp_path), str(csv_path))
+        tricky = "line1|with pipe\nline2"
+        m.save_case("owner/proj", tricky, "p", "b", "r", "l")
+
+        rows = self._read(csv_path)
+        assert rows[1][1] == tricky
+
+
+# --------------------------------------------------------------------------- #
+#  process_repository orchestration                                           #
+# --------------------------------------------------------------------------- #
+class FakeRA:
+    """Configurable stand-in for RepositoryActions."""
+
+    instances = []
+
+    def __init__(self, repository_name, repository_path):
+        self.repository_name = repository_name
+        self.repository_path = repository_path
+        self.cloned = False
+        FakeRA.instances.append(self)
+
+    # behaviour knobs (class-level defaults, overridden per test)
+    has_tests_value = True
+    repaired_cases = ()
+    annotate_map = {}
+
+    def clone_repository_last(self):
+        self.cloned = True
+        return "/fake/dest"
+
+    def has_tests(self):
+        return self.has_tests_value
+
+    def find_repaired_test_cases(self):
+        return set(self.repaired_cases)
+
+    def extract_and_annotate_code(self, case):
+        return self.annotate_map.get(case.test_name, "ANNOTATED")
+
+
+@pytest.fixture
+def patch_ra(monkeypatch):
+    FakeRA.instances = []
+    monkeypatch.setattr(main_repository_miner.repository_actions, "RepositoryActions", FakeRA)
+    # Neutralise the pip-uninstall subprocess call.
+    monkeypatch.setattr(main_repository_miner.subprocess, "run",
+                        lambda *a, **k: None)
+    return FakeRA
+
+
+class TestProcessRepository:
+    def _case(self, name="TestC.test_x"):
+        return Broken_to_repaired("br0ken", "f1xed", name, "tests/test_x.py", "LOG")
+
+    def test_saves_found_case(self, patch_ra, tmp_path):
+        case = self._case()
+        patch_ra.has_tests_value = True
+        patch_ra.repaired_cases = (case,)
+        patch_ra.annotate_map = {case.test_name: "GOOD-ANNOTATION"}
+
+        csv_path = tmp_path / "out.csv"
+        Main("owner/proj", str(tmp_path), str(csv_path)).process_repository()
+
+        with csv_path.open(encoding="utf-8") as fh:
+            rows = list(csv.reader(fh, delimiter="|"))
+        assert rows[1][1] == "GOOD-ANNOTATION"
+        assert rows[1][3] == "br0ken"
+        assert rows[1][4] == "f1xed"
+
+    def test_skips_when_no_tests(self, patch_ra, tmp_path):
+        patch_ra.has_tests_value = False
+        patch_ra.repaired_cases = (self._case(),)
+
+        csv_path = tmp_path / "out.csv"
+        Main("owner/proj", str(tmp_path), str(csv_path)).process_repository()
+        assert not csv_path.exists()  # save_case never called -> file never created
+
+    def test_skips_error_annotation(self, patch_ra, tmp_path):
+        case = self._case()
+        patch_ra.has_tests_value = True
+        patch_ra.repaired_cases = (case,)
+        patch_ra.annotate_map = {case.test_name: "Error"}
+
+        csv_path = tmp_path / "out.csv"
+        Main("owner/proj", str(tmp_path), str(csv_path)).process_repository()
+        assert not csv_path.exists()
+
+    def test_clone_failure_is_swallowed(self, patch_ra, tmp_path, monkeypatch):
+        def boom(self):
+            raise RuntimeError("clone exploded")
+        monkeypatch.setattr(FakeRA, "clone_repository_last", boom)
+
+        csv_path = tmp_path / "out.csv"
+        # Should not raise: process_repository wraps everything in try/except.
+        Main("owner/proj", str(tmp_path), str(csv_path)).process_repository()
+        assert not csv_path.exists()

--- a/tests/test_py_parser.py
+++ b/tests/test_py_parser.py
@@ -1,0 +1,152 @@
+"""Tests for repository_search/py_parser.py.
+
+These are fully internal: TestVerdict logic, the diff/verdict parsers, and the
+real ``compile_and_run_test_python`` / ``run_cmd`` against tiny temp projects
+(pytest is the only external dependency and is already installed).
+"""
+
+import time
+from pathlib import Path
+
+import pytest
+
+import py_parser
+from py_parser import (
+    TestVerdict,
+    compile_and_run_test_python,
+    parse_invalid_execution_py,
+    parse_successful_execution_py,
+    parse_test_failure_py,
+    run_cmd,
+)
+
+# TestVerdict is a production class (not a pytest test class); tell pytest to
+# skip collecting it now that it lives in this module's namespace.
+TestVerdict.__test__ = False
+
+
+# --------------------------------------------------------------------------- #
+#  TestVerdict                                                                 #
+# --------------------------------------------------------------------------- #
+class TestTestVerdict:
+    def test_success_predicates(self):
+        v = TestVerdict(TestVerdict.SUCCESS, None)
+        assert v.is_valid()
+        assert v.succeeded()
+        assert not v.is_broken()
+
+    def test_failure_is_valid_and_broken(self):
+        v = TestVerdict(TestVerdict.FAILURE, {3})
+        assert v.is_valid()
+        assert v.is_broken()
+        assert not v.succeeded()
+
+    def test_syntax_error_is_valid_and_broken(self):
+        v = TestVerdict(TestVerdict.SYNTAX_ERR, None)
+        assert v.is_valid()
+        assert v.is_broken()
+
+    @pytest.mark.parametrize(
+        "status",
+        [TestVerdict.TIMEOUT, TestVerdict.UNKNOWN, TestVerdict.TEST_NOT_EXECUTED,
+         TestVerdict.UNEXPECTED_FAILURE, TestVerdict.UNCONVENTIONAL],
+    )
+    def test_invalid_statuses(self, status):
+        v = TestVerdict(status, None)
+        assert not v.is_valid()
+        assert not v.is_broken()
+        assert not v.succeeded()
+
+    def test_to_dict_sorts_error_lines(self):
+        v = TestVerdict(TestVerdict.FAILURE, {7, 3, 5})
+        assert v.to_dict() == {"status": "failure", "error_lines": [3, 5, 7]}
+
+    def test_to_dict_with_none_error_lines(self):
+        v = TestVerdict(TestVerdict.SUCCESS, None)
+        assert v.to_dict() == {"status": "success", "error_lines": None}
+
+    def test_str(self):
+        assert "success" in str(TestVerdict(TestVerdict.SUCCESS, None))
+
+
+# --------------------------------------------------------------------------- #
+#  Log parsers                                                                 #
+# --------------------------------------------------------------------------- #
+class TestParsers:
+    def test_parse_successful(self):
+        v = parse_successful_execution_py("anything")
+        assert v.status == TestVerdict.SUCCESS
+
+    def test_parse_failure_extracts_line_numbers(self):
+        log = 'File "/x/test_mod.py", line 42, in test_thing\n  assert False'
+        v = parse_test_failure_py(log, "test_mod", "test_thing")
+        assert v.status == TestVerdict.FAILURE
+        assert v.error_lines == {42}
+
+    def test_parse_failure_generic_when_only_FAILED(self):
+        v = parse_test_failure_py("FAILED test_mod.py::test_thing", "test_mod", "test_thing")
+        assert v.status == TestVerdict.FAILURE
+        assert v.error_lines == set()
+
+    def test_parse_failure_returns_none_without_signal(self):
+        assert parse_test_failure_py("nothing useful", "test_mod", "test_thing") is None
+
+    def test_parse_invalid_syntax_error(self):
+        assert parse_invalid_execution_py("E   SyntaxError: bad").status == TestVerdict.SYNTAX_ERR
+
+    def test_parse_invalid_unknown(self):
+        assert parse_invalid_execution_py("random noise").status == TestVerdict.UNKNOWN
+
+
+# --------------------------------------------------------------------------- #
+#  run_cmd                                                                     #
+# --------------------------------------------------------------------------- #
+class TestRunCmd:
+    def test_returns_output_and_zero(self):
+        rc, out = run_cmd(["python", "-c", "print('hello-out')"], timeout=30, cwd=".", env=None)
+        assert rc == 0
+        assert "hello-out" in out
+
+    def test_captures_nonzero_exit(self):
+        rc, _ = run_cmd(["python", "-c", "import sys; sys.exit(3)"], timeout=30, cwd=".", env=None)
+        assert rc == 3
+
+    def test_timeout_returns_124(self):
+        start = time.time()
+        rc, _ = run_cmd(["python", "-c", "import time; time.sleep(30)"], timeout=1, cwd=".", env=None)
+        assert rc == 124
+        assert time.time() - start < 15  # was actually killed, not waited out
+
+
+# --------------------------------------------------------------------------- #
+#  compile_and_run_test_python                                                 #
+# --------------------------------------------------------------------------- #
+class TestCompileAndRun:
+    def _project(self, tmp_path, body):
+        f = tmp_path / "test_mod.py"
+        f.write_text(body, encoding="utf-8")
+        return tmp_path
+
+    def test_passing_test_is_success(self, tmp_path):
+        proj = self._project(tmp_path, "def test_ok():\n    assert 1 + 1 == 2\n")
+        v = compile_and_run_test_python(proj, "test_mod.py", "test_ok", tmp_path)
+        assert v.status == TestVerdict.SUCCESS
+
+    def test_failing_test_is_failure(self, tmp_path):
+        proj = self._project(tmp_path, "def test_bad():\n    assert 1 + 1 == 3\n")
+        v = compile_and_run_test_python(proj, "test_mod.py", "test_bad", tmp_path)
+        assert v.status == TestVerdict.FAILURE
+
+    def test_syntax_error_is_syntax_err(self, tmp_path):
+        proj = self._project(tmp_path, "def test_syn(:\n    pass\n")
+        v = compile_and_run_test_python(proj, "test_mod.py", "test_syn", tmp_path)
+        assert v.status == TestVerdict.SYNTAX_ERR
+
+    def test_missing_file_raises(self, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            compile_and_run_test_python(tmp_path, "does_not_exist.py", "test_x", tmp_path)
+
+    def test_timeout_is_timeout_verdict(self, tmp_path):
+        proj = self._project(tmp_path, "import time\ndef test_slow():\n    time.sleep(30)\n")
+        v = compile_and_run_test_python(proj, "test_mod.py", "test_slow", tmp_path, timeout=1)
+        assert v.status == TestVerdict.TIMEOUT

--- a/tests/test_repository_actions_git.py
+++ b/tests/test_repository_actions_git.py
@@ -1,0 +1,152 @@
+"""Real git-operation tests for repository_search/repository_actions.py.
+
+These exercise clone / checkout / commit-navigation against a small, well-known
+repository (benjaminp/six) pinned to stable, immutable commit SHAs.  They are
+skipped automatically when git or the network is unavailable.
+
+``clone_repository_last`` bundles a ``pip install .`` step that would mutate the
+outer interpreter's environment; we intercept *only* that pip call so the real
+git clone + HEAD-resolution logic still runs, without polluting the env.
+"""
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+import repository_actions
+from conftest import (
+    SIX_REPO_NAME,
+    SIX_REPO_URL,
+    SIX_SHA_GRANDPARENT,
+    SIX_SHA_HEAD,
+    SIX_SHA_PARENT,
+)
+
+
+def _head_sha(repo_dir):
+    out = subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=str(repo_dir),
+        capture_output=True, text=True,
+    )
+    return out.stdout.strip()
+
+
+@pytest.fixture
+def actions(six_clone):
+    repository_path, repository_name = six_clone
+    a = repository_actions.RepositoryActions(repository_name, repository_path)
+    # Deterministic starting point for every test.
+    assert a.git_checkout_with_retry(str(a.repo_dir), SIX_SHA_HEAD)
+    a.current_hash = SIX_SHA_HEAD
+    a.visited_commits = {SIX_SHA_HEAD}
+    return a
+
+
+# --------------------------------------------------------------------------- #
+#  clone_repository_last (git parts only; pip install intercepted)            #
+# --------------------------------------------------------------------------- #
+class TestCloneRepositoryLast:
+    def test_clone_sets_repo_dir_and_hash(self, git_available, tmp_path, monkeypatch):
+        # Network probe: skip cleanly if we cannot reach the remote.
+        probe = subprocess.run(["git", "ls-remote", SIX_REPO_URL, "HEAD"],
+                                capture_output=True, text=True)
+        if probe.returncode != 0:
+            pytest.skip("network unavailable for git ls-remote")
+
+        real_run = subprocess.run
+
+        def fake_run(cmd, *args, **kwargs):
+            # Intercept the `pip install .` that clone_repository_last performs
+            # so it does not touch the outer environment.
+            if any("pip" == str(c) or str(c).endswith("pip") for c in cmd) or "install" in cmd:
+                return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+            return real_run(cmd, *args, **kwargs)
+
+        monkeypatch.setattr(repository_actions.subprocess, "run", fake_run)
+
+        a = repository_actions.RepositoryActions(SIX_REPO_NAME, str(tmp_path))
+        dest = a.clone_repository_last()
+
+        assert Path(dest).exists()
+        assert (Path(dest) / ".git").exists()
+        assert len(a.current_hash) == 40
+        assert a.current_hash in a.visited_commits
+        assert a.current_hash == _head_sha(dest)
+
+
+# --------------------------------------------------------------------------- #
+#  checkout_commit / git_checkout_with_retry                                  #
+# --------------------------------------------------------------------------- #
+class TestCheckout:
+    def test_checkout_commit_moves_head(self, actions):
+        assert actions.checkout_commit(SIX_SHA_PARENT, str(actions.repo_dir)) is True
+        assert _head_sha(actions.repo_dir) == SIX_SHA_PARENT
+
+    def test_checkout_commit_bad_hash_returns_false(self, actions):
+        assert actions.checkout_commit("0" * 40, str(actions.repo_dir)) is False
+
+    def test_checkout_with_retry_success(self, actions):
+        assert actions.git_checkout_with_retry(str(actions.repo_dir), SIX_SHA_GRANDPARENT) is True
+        assert _head_sha(actions.repo_dir) == SIX_SHA_GRANDPARENT
+
+    def test_checkout_with_retry_failure_is_bounded(self, actions, monkeypatch):
+        # Don't actually sleep through the exponential backoff.
+        monkeypatch.setattr(repository_actions.time, "sleep", lambda *_: None)
+        assert actions.git_checkout_with_retry(str(actions.repo_dir), "0" * 40, retries=2) is False
+
+
+# --------------------------------------------------------------------------- #
+#  commit navigation                                                          #
+# --------------------------------------------------------------------------- #
+class TestCommitNavigation:
+    def test_move_to_earlier_commit_follows_parent(self, actions):
+        result = actions.move_to_earlier_commit()
+        assert result == SIX_SHA_PARENT
+        assert actions.current_hash == SIX_SHA_PARENT
+        assert actions.previous_hash == SIX_SHA_HEAD
+        assert _head_sha(actions.repo_dir) == SIX_SHA_PARENT
+
+    def test_move_to_earlier_detects_cycle(self, actions):
+        # Pretend the parent was already visited -> refuse to move.
+        actions.visited_commits.add(SIX_SHA_PARENT)
+        assert actions.move_to_earlier_commit() == "Error"
+
+    def test_move_to_earlier_respects_max_commits(self, actions):
+        actions.commit_counter = 500
+        assert actions.move_to_earlier_commit() == "Error"
+
+    def test_move_to_later_returns_to_child(self, actions):
+        assert actions.move_to_earlier_commit() == SIX_SHA_PARENT
+        assert actions.move_to_later_commit() == SIX_SHA_HEAD
+        assert _head_sha(actions.repo_dir) == SIX_SHA_HEAD
+
+    def test_move_to_later_without_previous_is_error(self, actions):
+        actions.previous_hash = None
+        assert actions.move_to_later_commit() == "Error"
+
+
+# --------------------------------------------------------------------------- #
+#  test discovery against the real checked-out tree                           #
+# --------------------------------------------------------------------------- #
+class TestDiscoveryOnRealTree:
+    def test_has_tests(self, actions):
+        actions.checkout_commit(SIX_SHA_PARENT, str(actions.repo_dir))
+        assert actions.has_tests() is True
+
+    def test_list_test_files_includes_test_six(self, actions):
+        actions.checkout_commit(SIX_SHA_PARENT, str(actions.repo_dir))
+        names = {p.name for p in actions.list_test_files()}
+        assert "test_six.py" in names
+
+    def test_find_test_methods_on_real_file(self, actions):
+        actions.checkout_commit(SIX_SHA_PARENT, str(actions.repo_dir))
+        methods = actions.find_test_methods("test_six.py")
+        flat = {m[1] for m in methods}
+        assert "test_add_doc" in flat
+        assert "test_integer_types" in flat
+
+    def test_extract_method_code_on_real_file(self, actions):
+        actions.checkout_commit(SIX_SHA_PARENT, str(actions.repo_dir))
+        code = actions.extract_method_code("test_six.py", "test_add_doc")
+        assert "def test_add_doc():" in code

--- a/tests/test_repository_actions_internal.py
+++ b/tests/test_repository_actions_internal.py
@@ -1,0 +1,352 @@
+"""Internal tests for repository_search/repository_actions.py.
+
+These cover the AST parsing, diffing, annotation and filesystem-walk helpers
+without touching git or the network.  They use the ``make_actions`` factory
+(see conftest.py) to materialise a fake repo on disk.
+"""
+
+import os
+import textwrap
+
+import pytest
+
+
+def dedent(s):
+    return textwrap.dedent(s).lstrip("\n")
+
+
+# --------------------------------------------------------------------------- #
+#  find_test_methods                                                          #
+# --------------------------------------------------------------------------- #
+class TestFindTestMethods:
+    SRC = dedent(
+        """
+        import pytest
+
+        def test_top_level():
+            assert True
+
+        @pytest.mark.parametrize("x", [1, 2])
+        def test_parametrized(x):
+            assert x
+
+        class TestThing:
+            def test_in_class(self):
+                assert True
+            def helper(self):
+                return 1
+
+        import unittest
+        class MyCase(unittest.TestCase):
+            def test_case_method(self):
+                self.assertTrue(True)
+        """
+    )
+
+    def _names(self, actions):
+        return {tuple(x) for x in actions.find_test_methods("tests/test_x.py")}
+
+    def test_finds_plain_test_function(self, make_actions):
+        a = make_actions({"tests/test_x.py": self.SRC})
+        assert ("tests/test_x.py", "test_top_level") in self._names(a)
+
+    def test_skips_parametrized_top_level(self, make_actions):
+        a = make_actions({"tests/test_x.py": self.SRC})
+        assert ("tests/test_x.py", "test_parametrized") not in self._names(a)
+
+    def test_finds_class_qualified_methods(self, make_actions):
+        a = make_actions({"tests/test_x.py": self.SRC})
+        names = self._names(a)
+        assert ("tests/test_x.py", "TestThing.test_in_class") in names
+        assert ("tests/test_x.py", "MyCase.test_case_method") in names
+
+    def test_ignores_non_test_helpers(self, make_actions):
+        a = make_actions({"tests/test_x.py": self.SRC})
+        assert ("tests/test_x.py", "TestThing.helper") not in self._names(a)
+
+    def test_unreadable_file_returns_empty(self, make_actions):
+        a = make_actions({})  # file not created
+        assert a.find_test_methods("tests/missing.py") == []
+
+    def test_syntax_error_returns_empty(self, make_actions):
+        a = make_actions({"tests/bad.py": "def test_x(:\n  pass\n"})
+        assert a.find_test_methods("tests/bad.py") == []
+
+
+# --------------------------------------------------------------------------- #
+#  extract_method_code / _get_method_line_range                               #
+# --------------------------------------------------------------------------- #
+class TestExtractMethodCode:
+    SRC = dedent(
+        """
+        import pytest
+
+        @staticmethod
+        def test_decorated():
+            x = 1
+            assert x == 1
+
+        @pytest.mark.parametrize("y", [1])
+        def test_param(y):
+            assert y
+
+        class TestC:
+            def test_method(self):
+                return 7
+        """
+    )
+
+    def test_extracts_with_decorator(self, make_actions):
+        a = make_actions({"t.py": self.SRC})
+        code = a.extract_method_code("t.py", "test_decorated")
+        assert code.startswith("@staticmethod")
+        assert "def test_decorated():" in code
+        assert "assert x == 1" in code
+
+    def test_parametrized_returns_empty(self, make_actions):
+        a = make_actions({"t.py": self.SRC})
+        assert a.extract_method_code("t.py", "test_param") == ""
+
+    def test_extracts_class_method(self, make_actions):
+        a = make_actions({"t.py": self.SRC})
+        code = a.extract_method_code("t.py", "TestC.test_method")
+        assert "def test_method(self):" in code
+        assert "return 7" in code
+
+    def test_missing_file_returns_empty(self, make_actions):
+        a = make_actions({})
+        assert a.extract_method_code("nope.py", "test_x") == ""
+
+    def test_unknown_method_returns_empty(self, make_actions):
+        a = make_actions({"t.py": self.SRC})
+        assert a.extract_method_code("t.py", "test_absent") == ""
+
+    def test_line_range_includes_decorator(self, make_actions):
+        a = make_actions({"t.py": self.SRC})
+        rng = a._get_method_line_range("t.py", "test_decorated")
+        assert rng is not None
+        start, end = rng
+        lines = self.SRC.splitlines()
+        chunk = "\n".join(lines[start:end])
+        assert chunk.startswith("@staticmethod")
+        assert "assert x == 1" in chunk
+
+    def test_line_range_missing_returns_none(self, make_actions):
+        a = make_actions({"t.py": self.SRC})
+        assert a._get_method_line_range("t.py", "test_absent") is None
+
+
+# --------------------------------------------------------------------------- #
+#  extract_test_imports                                                       #
+# --------------------------------------------------------------------------- #
+class TestExtractImports:
+    def test_collects_import_statements(self, make_actions):
+        src = dedent(
+            """
+            import os
+            from pathlib import Path
+            x = 1
+            import sys
+            """
+        )
+        a = make_actions({"t.py": src})
+        imports = a.extract_test_imports("t.py")
+        assert "import os" in imports
+        assert "from pathlib import Path" in imports
+        assert "import sys" in imports
+        assert "x = 1" not in imports
+
+    def test_unparseable_returns_empty(self, make_actions):
+        a = make_actions({"t.py": "def f(:\n"})
+        assert a.extract_test_imports("t.py") == ""
+
+
+# --------------------------------------------------------------------------- #
+#  is_test_method_changed                                                     #
+# --------------------------------------------------------------------------- #
+class TestIsTestMethodChanged:
+    def test_identical_is_unchanged(self, make_actions):
+        a = make_actions({})
+        code = "def test_x():\n    assert True\n"
+        assert a.is_test_method_changed(code, code) is False
+
+    def test_comment_only_change_is_unchanged(self, make_actions):
+        a = make_actions({})
+        before = "def test_x():\n    assert True\n"
+        after = "def test_x():\n    # a new comment\n    assert True\n"
+        assert a.is_test_method_changed(before, after) is False
+
+    def test_real_change_is_detected(self, make_actions):
+        a = make_actions({})
+        before = "def test_x():\n    assert foo() == 1\n"
+        after = "def test_x():\n    assert foo() == 2\n"
+        assert a.is_test_method_changed(before, after) is True
+
+    def test_whitespace_only_change_is_unchanged(self, make_actions):
+        a = make_actions({})
+        before = "def test_x():\n    assert True\n"
+        after = "def test_x():\n    assert True   \n"
+        assert a.is_test_method_changed(before, after) is False
+
+
+# --------------------------------------------------------------------------- #
+#  filter_diff_lines                                                          #
+# --------------------------------------------------------------------------- #
+class TestFilterDiffLines:
+    def test_drops_headers(self, make_actions):
+        a = make_actions({})
+        lines = ["--- a", "+++ b", "@@ -1 +1 @@", "-old", "+new", " ctx"]
+        out = a.filter_diff_lines(lines)
+        assert out == ["-old", "+new", " ctx"]
+
+    def test_strip_markers(self, make_actions):
+        a = make_actions({})
+        lines = ["@@ -1 +1 @@", "-old", "+new", " ctx"]
+        out = a.filter_diff_lines(lines, strip_markers=True)
+        assert out == ["old", "new", " ctx"]
+
+
+# --------------------------------------------------------------------------- #
+#  annotate_code                                                              #
+# --------------------------------------------------------------------------- #
+class TestAnnotateCode:
+    def test_builds_annotated_blocks(self, make_actions):
+        a = make_actions({"t.py": "import os\n"})
+        broken = "def test_x():\n    assert foo() == 1"
+        repaired = "def test_x():\n    assert foo() == 2"
+        source = "class Helper:\n[<HUNK>] Helper.foo\n...\n[</HUNK>]"
+
+        out = a.annotate_code(broken, repaired, source, "t.py")
+
+        assert "[<TESTCONTEXT>]" in out and "[</TESTCONTEXT>]" in out
+        assert "[<BREAKAGE>]" in out and "[</BREAKAGE>]" in out
+        assert "[<REPAIREDTEST>]" in out and "[</REPAIREDTEST>]" in out
+        assert "[<REPAIRCONTEXT>]" in out and "[</REPAIRCONTEXT>]" in out
+        # imports pulled from the on-disk test file
+        assert "import os" in out
+        # the changed lines land in the right blocks
+        breakage = out.split("[<BREAKAGE>]")[1].split("[</BREAKAGE>]")[0]
+        repaired_block = out.split("[<REPAIREDTEST>]")[1].split("[</REPAIREDTEST>]")[0]
+        assert "assert foo() == 1" in breakage
+        assert "assert foo() == 2" in repaired_block
+        assert source in out
+
+    def test_no_diff_returns_empty(self, make_actions):
+        a = make_actions({"t.py": "import os\n"})
+        same = "def test_x():\n    assert True"
+        assert a.annotate_code(same, same, "src", "t.py") == ""
+
+
+# --------------------------------------------------------------------------- #
+#  format_inline_diff                                                         #
+# --------------------------------------------------------------------------- #
+class TestFormatInlineDiff:
+    def test_groups_add_and_del_blocks(self, make_actions):
+        a = make_actions({})
+        diff = ["@@ -1 +1 @@", "-old1", "-old2", "+new1", " ctx"]
+        out = a.format_inline_diff("Cls.method", diff)
+        assert "[<HUNK>]" in out and "[</HUNK>]" in out
+        assert "[<DEL>]" in out and "[</DEL>]" in out
+        assert "[<ADD>]" in out and "[</ADD>]" in out
+        del_block = out.split("[<DEL>]")[1].split("[</DEL>]")[0]
+        assert "old1" in del_block and "old2" in del_block
+        add_block = out.split("[<ADD>]")[1].split("[</ADD>]")[0]
+        assert "new1" in add_block
+        assert "ctx" in out
+
+    def test_empty_diff_returns_empty(self, make_actions):
+        a = make_actions({})
+        assert a.format_inline_diff("Cls.method", []) == ""
+
+
+# --------------------------------------------------------------------------- #
+#  extract_executed_methods_from_file                                         #
+# --------------------------------------------------------------------------- #
+class TestExtractExecutedMethods:
+    SRC = dedent(
+        """
+        class Foo:
+            def bar(self):
+                return 1
+
+        def baz():
+            return 2
+        """
+    )
+
+    def test_class_method_keyed_by_class(self, make_actions, tmp_path):
+        a = make_actions({"mod.py": self.SRC})
+        path = tmp_path / "proj" / "mod.py"
+        methods = a.extract_executed_methods_from_file(str(path), {2, 3})
+        assert "Foo.bar" in methods
+        assert "def bar" in methods["Foo.bar"]
+
+    def test_global_function_keyed_global(self, make_actions, tmp_path):
+        a = make_actions({"mod.py": self.SRC})
+        path = tmp_path / "proj" / "mod.py"
+        methods = a.extract_executed_methods_from_file(str(path), {6})
+        assert "Global.baz" in methods
+
+    def test_uncovered_lines_yield_nothing(self, make_actions, tmp_path):
+        a = make_actions({"mod.py": self.SRC})
+        path = tmp_path / "proj" / "mod.py"
+        assert a.extract_executed_methods_from_file(str(path), {999}) == {}
+
+    def test_unreadable_returns_empty(self, make_actions):
+        a = make_actions({})
+        assert a.extract_executed_methods_from_file("/no/such/file.py", {1}) == {}
+
+
+# --------------------------------------------------------------------------- #
+#  has_tests / list_test_files                                                #
+# --------------------------------------------------------------------------- #
+class TestFilesystemWalkers:
+    def test_has_tests_true(self, make_actions):
+        a = make_actions({"pkg/test_a.py": "def test_a():\n    pass\n",
+                          "pkg/util.py": "def helper():\n    pass\n"})
+        assert a.has_tests() is True
+
+    def test_has_tests_false(self, make_actions):
+        a = make_actions({"pkg/util.py": "def helper():\n    pass\n"})
+        assert a.has_tests() is False
+
+    def test_list_test_files_selects_only_test_files(self, make_actions):
+        a = make_actions({
+            "pkg/test_a.py": "def test_a():\n    pass\n",
+            "pkg/util.py": "def helper():\n    pass\n",
+            "pkg/sub/test_b.py": "def test_b():\n    pass\n",
+        })
+        names = {p.name for p in a.list_test_files()}
+        assert names == {"test_a.py", "test_b.py"}
+
+
+# --------------------------------------------------------------------------- #
+#  _invalidate_bytecode_cache                                                 #
+# --------------------------------------------------------------------------- #
+class TestInvalidateBytecodeCache:
+    def test_removes_pycache_dirs_and_pyc_files(self, make_actions, tmp_path):
+        a = make_actions({"pkg/mod.py": "x = 1\n"})
+        work = tmp_path / "proj"
+        cache = work / "pkg" / "__pycache__"
+        cache.mkdir(parents=True)
+        (cache / "mod.cpython-311.pyc").write_bytes(b"stale")
+        loose = work / "pkg" / "other.pyc"
+        loose.write_bytes(b"stale")
+
+        a._invalidate_bytecode_cache()
+
+        assert not cache.exists()
+        assert not loose.exists()
+        assert (work / "pkg" / "mod.py").exists()  # source untouched
+
+
+# --------------------------------------------------------------------------- #
+#  set_full_permissions                                                       #
+# --------------------------------------------------------------------------- #
+class TestSetFullPermissions:
+    def test_grants_rwx(self, make_actions, tmp_path):
+        a = make_actions({"pkg/mod.py": "x = 1\n"})
+        a.set_full_permissions()
+        f = tmp_path / "proj" / "pkg" / "mod.py"
+        mode = os.stat(f).st_mode & 0o777
+        assert mode & 0o700 == 0o700  # at least owner rwx


### PR DESCRIPTION
## Summary
This PR adds a comprehensive test suite for the `repository_search` module, covering all major components with a mix of unit tests, integration tests, and end-to-end tests. The test suite is designed to run deterministically and offline by stubbing network requests, subprocess calls, and other external dependencies.

## Key Changes

### Test Files Added
- **`tests/test_github_search.py`** (356 lines): Tests for `GitHubSearch` class covering initialization, GitHub API interactions, rate limiting, search pagination, and repository processing with timeout handling
- **`tests/test_repository_actions_internal.py`** (352 lines): Internal tests for `RepositoryActions` covering AST parsing, test method extraction, code diffing, annotation, and filesystem operations without git
- **`tests/test_py_parser.py`** (152 lines): Tests for `py_parser` module covering test verdict logic, execution parsers, and command execution
- **`tests/test_repository_actions_git.py`** (152 lines): Real git operation tests against a pinned, stable repository (benjaminp/six) for clone, checkout, and commit navigation
- **`tests/test_main_repository_miner.py`** (146 lines): Tests for `Main` class covering CSV output, repository processing orchestration, and case annotation
- **`tests/test_find_repaired_cases_integration.py`** (125 lines): End-to-end integration test of the core `find_repaired_test_cases()` logic against a real local git repository with a genuine broken→repaired scenario
- **`tests/conftest.py`** (114 lines): Shared pytest fixtures, path setup, git availability detection, and factory functions for creating test repositories

### Configuration Files Added
- **`pytest.ini`**: Pytest configuration specifying test paths, output options, and warning filters

### Source Code Modifications
- **`repository_search/repository_actions.py`**: Added bytecode cache invalidation in `run_test_with_overridden_test_code()` to prevent pytest from reusing stale `.pyc` files when testing overridden test code. This ensures that overridden tests correctly fail when they should, preventing genuine repaired cases from being silently discarded.

### Git Configuration
- **`.gitignore`**: Updated to exclude Python cache artifacts (`__pycache__/`, `*.pyc`, `.pytest_cache/`)

## Notable Implementation Details

- **Deterministic Testing**: All network requests, subprocess calls, and sleep operations are stubbed using pytest's `monkeypatch` fixture, allowing tests to run offline and reproducibly
- **Fixture Architecture**: Uses a `make_actions` factory fixture to create fake on-disk repositories for testing without git operations
- **Real Git Tests**: Integration tests use a pinned, immutable commit SHA from benjaminp/six to ensure deterministic behavior while exercising real git operations
- **Bytecode Cache Fix**: The source code change addresses a subtle bug where Python's `.pyc` caching could cause test overrides to incorrectly pass, which would silently discard valid repaired test cases
- **Dual Import Paths**: Test configuration handles the production code's mixed import roots (project root for data types, `repository_search/` for modules)

https://claude.ai/code/session_01Tkx8XBDTU1hp2ZyedrZxf3